### PR TITLE
Add missing Inter font variables

### DIFF
--- a/Theme_Spotify.xml
+++ b/Theme_Spotify.xml
@@ -55,6 +55,8 @@
   <b:if cond='not data:view.isLayoutMode'>
     <b:skin version='1.0.1'><![CDATA[/*
 <Variable name="keycolor" description="Main color" type="color" default="#2ebd59"  value="#2ebd59"/>
+<Variable name="interBold18" type="font" default="bold 18px Inter, sans-serif" value="bold 18px Inter, sans-serif"/>
+<Variable name="interNormal16" type="font" default="normal 16px Inter, sans-serif" value="normal 16px Inter, sans-serif"/>
 
 <Group description="Backgrounds">
   <Variable name="main.font.color" description="Text color" type="color" default="#ffffff"  value="#ffffff"/>


### PR DESCRIPTION
## Summary
- define interBold18 and interNormal16 font variables before they are referenced
- keep sidebar title and caption fonts pointing to those shared variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cac88d9eb883339106f594d8615e85