### PR TITLE
Adjust skin to load external stylesheet

### DIFF
--- a/Theme_Spotify.xml
+++ b/Theme_Spotify.xml
@@ -53,7 +53,8 @@
 	<script src='https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js'/>
 
   <b:if cond='not data:view.isLayoutMode'>
-    <b:skin version='1.0.1'><link expr:href='data:blog.url/ + "path/styles.css"' rel='stylesheet'/></b:skin>
+    <b:skin version='1.0.1'><![CDATA[]]></b:skin>
+    <link expr:href='data:blog.url/ + "path/styles.css"' rel='stylesheet'/>
   </b:if>
   
  <b:if cond='data:view.isLayoutMode'>


### PR DESCRIPTION
## Summary
- replace the inline stylesheet link inside the `<b:skin>` block with an empty CDATA wrapper
- add the external stylesheet `<link>` tag as a sibling element within the non-layout `<b:if>` block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cacfe770708333a4efb23592a240a8