### PR TITLE
Fix sidebar title font variable description

### DIFF
--- a/Theme_Spotify.xml
+++ b/Theme_Spotify.xml
@@ -75,7 +75,7 @@
 </Group>
 
 <Group description="Header items" selector="#main-top">
-  <Variable name="sidebar.title.font" description=" Font" type="font" default="$(interBold18)" value="bold 18px Inter, sans-serif"/>
+  <Variable name="sidebar.title.font" description="Font" type="font" default="$(interBold18)" value="bold 18px Inter, sans-serif"/>
   <Variable name="sidebar.caption.font" description="Sidebar Font caption" type="font" default="$(interNormal16)"  value="normal 16px Inter, sans-serif"/>
 </Group>
 


### PR DESCRIPTION
## Summary
- remove the leading space from the sidebar title font variable description so Blogger no longer flags it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad3dfcca88333823a9215e990724d